### PR TITLE
Renamed check-storm-workers to check-storm-supervisors

### DIFF
--- a/bin/check-storm-supervisors.rb
+++ b/bin/check-storm-supervisors.rb
@@ -8,7 +8,7 @@
 # Released under the same terms as Sensu (the MIT license); see LICENSE
 # for details.
 #
-# Check the number of workers (supervisors) for a given cluster and compare to warn/minimum thresholds
+# Check the number of supervisors for a given cluster and compare to warn/minimum thresholds
 
 require 'sensu-plugin/check/cli'
 require 'rest-client'
@@ -17,7 +17,7 @@ require 'uri'
 require 'json'
 require 'base64'
 
-class CheckStormCapacity < Sensu::Plugin::Check::CLI
+class CheckStormSupervisors < Sensu::Plugin::Check::CLI
   option :host,
          short: '-h',
          long: '--host=VALUE',
@@ -45,8 +45,8 @@ class CheckStormCapacity < Sensu::Plugin::Check::CLI
          long: '--ssl'
 
   option :crit,
-         short: '-m',
-         long: '--minimum=VALUE',
+         short: '-c',
+         long: '--critical=VALUE',
          description: 'Minimum (critical) workers',
          required: true,
          proc: proc { |l| l.to_i }
@@ -92,15 +92,15 @@ class CheckStormCapacity < Sensu::Plugin::Check::CLI
     end
 
     cluster = JSON.parse(r.to_str)
-    workers = cluster['supervisors'].to_i
+    supervisors = cluster['supervisors'].to_i
 
-    if workers < config[:crit]
-      critical "worker count #{workers} is below allowed minimum of #{config[:crit]}"
-    elsif workers < config[:warn]
-      warning "worker count #{workers} is below warn threshold of #{config[:warn]}"
+    if supervisors < config[:crit]
+      critical "supervisor count #{supervisors} is below allowed minimum of #{config[:crit]}"
+    elsif supervisors < config[:warn]
+      warning "supervisor count #{supervisors} is below warn threshold of #{config[:warn]}"
     end
 
-    ok 'worker count OK'
+    ok 'supervisor count OK'
 
   rescue Errno::ECONNREFUSED => e
     critical 'Storm is not responding' + e.message

--- a/bin/check-storm-supervisors.rb
+++ b/bin/check-storm-supervisors.rb
@@ -1,6 +1,6 @@
 #!/usr/bin/env ruby
 #
-# Storm Workers Check
+# Storm Supervisors Check
 # ===
 #
 # Copyright 2016 Andy Royle <ajroyle@gmail.com>
@@ -47,7 +47,7 @@ class CheckStormSupervisors < Sensu::Plugin::Check::CLI
   option :crit,
          short: '-c',
          long: '--critical=VALUE',
-         description: 'Minimum (critical) workers',
+         description: 'Minimum (critical) supervisors',
          required: true,
          proc: proc { |l| l.to_i }
 

--- a/bin/metrics-storm-topologies.rb
+++ b/bin/metrics-storm-topologies.rb
@@ -17,7 +17,7 @@ require 'uri'
 require 'json'
 require 'base64'
 
-class MetricsStormCapacity < Sensu::Plugin::Metric::CLI::Graphite
+class MetricsStormTopologies < Sensu::Plugin::Metric::CLI::Graphite
   option :host,
          short: '-h',
          long: '--host=VALUE',


### PR DESCRIPTION
Also removed all references to workers inside the file since (contrary to what the script description states) they are not the same as supervisors. The **:crit** parameter flags where changed to **-c** and **--critical** for consistency with the rest of the scripts.